### PR TITLE
fixed memory leak

### DIFF
--- a/src/hasher.js
+++ b/src/hasher.js
@@ -44,7 +44,7 @@ function handle(msg) {
     var cb = hashMap[hashStr]
     if (cb) {
       log.debug('hasher.handle invoking cb for global-client')
-      _.omit(hashMap, hashStr)
+      delete hashMap[hashStr]
       return cb(msg)
     }
   }


### PR DESCRIPTION
_.omit returns a new object without specified properties, but it doesn't modify a source object.