### PR TITLE
SIGTERM-CONTROL: Added control over SIGTERM handling by PROCESSEXIT environment variable, set NO not to exit

### DIFF
--- a/src/start-io.js
+++ b/src/start-io.js
@@ -10,6 +10,7 @@ const socketIO = require('socket.io')
 const log = require(path.join(__dirname, 'log'))
 const app = express()
 const server = http.Server(app)
+process.env.PROCESSEXIT =  process.env.PROCESSEXIT || 'YES'; 
 
 /**
  * Start a Socket IO server connecting to a brand new Express server for use in dev. Sets global.io too.
@@ -85,7 +86,11 @@ function ioStart(options) {
 }
 
 /* istanbul ignore next */
-const cleanExit = () => { process.exit() }
+const cleanExit = () => {
+  if(process.env.PROCESSEXIT === 'YES'){
+    process.exit();
+  }
+};
 process.on('SIGINT', cleanExit) // catch ctrl-c
 process.on('SIGTERM', cleanExit) // catch kill
 process.on('uncaughtException', (e) => log.error(`${e.message} ${e.stack}`));


### PR DESCRIPTION
SIGTERM-CONTROL: Added control over SIGTERM handling by PROCESSEXIT environment variable (set NO not to call process.exit() in this package). If environment variable PROCESSEXIT is set to NO then this package would not exit when SIGTERM is called in the project (calling of process.exit() is skipped) where this package is included. Default behaviour remains the same (process.exit() is called). This way SIGTERM can be handled in the project where this package is included (if required by setting PROCESSEXIT environment variable).